### PR TITLE
Fix exports specificity

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
         "import": "./dist/node/index.mjs",
         "require": "./dist/node/index.js"
       },
-      "default": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.js"
     },
     "./server": {
       "import": "./server/index.mjs",


### PR DESCRIPTION
Based https://nodejs.org/api/packages.html#packages_subpath_exports, the import names must be specified from the most specific to the least. So `default` should be last.

Needed to get Vite (and possibly Snowpack) working.